### PR TITLE
Update Yarn instructions to use `yarn add`

### DIFF
--- a/next-styled-components/README.md
+++ b/next-styled-components/README.md
@@ -61,7 +61,7 @@ Install the dependencies
 
 ```shell
 yarn add styled-components
-npm install -D twin.macro tailwindcss babel-plugin-styled-components babel-plugin-macros react-is
+yarn add twin.macro tailwindcss babel-plugin-styled-components babel-plugin-macros react-is --dev
 ```
 
 </details>


### PR DESCRIPTION
Proposes a change for the Yarn dependency installation instructions:

Under `Getting started > Installation > Install the dependencies > Install with Yarn`, change the following:

 `npm install -D {deps}` => `yarn add {deps} --dev`