### PR TITLE
remove trailing comma from package.json example

### DIFF
--- a/cra-styled-components/README.md
+++ b/cra-styled-components/README.md
@@ -141,7 +141,7 @@ b) Or in `package.json`:
     "css": {
       "import": "css",
       "from": "styled-components"
-    },
+    }
   }
 },
 ```


### PR DESCRIPTION
My linter caught this when I pasted the example code. Thought I'd update it in the docs :)