### PR TITLE
fix: emotion server side render

### DIFF
--- a/next-emotion-typescript/pages/_app.tsx
+++ b/next-emotion-typescript/pages/_app.tsx
@@ -1,11 +1,13 @@
-import { AppProps } from 'next/app'
+import { cache } from '@emotion/css'
+import { CacheProvider } from '@emotion/react'
+import type { AppProps } from 'next/app'
 import GlobalStyles from './../styles/GlobalStyles'
 
 const App = ({ Component, pageProps }: AppProps) => (
-  <div>
+  <CacheProvider value={cache}>
     <GlobalStyles />
     <Component {...pageProps} />
-  </div>
+  </CacheProvider>
 )
 
 export default App

--- a/next-emotion/pages/_app.js
+++ b/next-emotion/pages/_app.js
@@ -1,10 +1,12 @@
+import { cache } from '@emotion/css'
+import { CacheProvider } from '@emotion/react'
 import GlobalStyles from './../styles/GlobalStyles'
 
 const App = ({ Component, pageProps }) => (
-  <>
+  <CacheProvider value={cache}>
     <GlobalStyles />
     <Component {...pageProps} />
-  </>
+  </CacheProvider>
 )
 
 export default App


### PR DESCRIPTION
## Fix ben-rogerson/twin.macro#646

> `@emotion/server` by default handles the cache from `@emotion/css` but you are using the one created in `@emotion/react`. If you want to use `extractCritical` then I recommend using `CacheProvider`, cache created per request, and `extractCriticalToChunks`.
https://github.com/emotion-js/emotion/issues/2683#issuecomment-1069718324

