### PR TITLE
next-stitches-typescript: fix styled.<tag>, styled(), and css types

### DIFF
--- a/next-stitches-typescript/README.md
+++ b/next-stitches-typescript/README.md
@@ -212,13 +212,96 @@ Because twin routes the `styled` and `css`, you’ll need complete the typescrip
 Create a `types/twin.d.ts` file in your project root and add these declarations:
 
 ```typescript
-// types/twin.d.ts
 import 'twin.macro'
 import { css as cssImport } from '@stitches/react'
-import styledImport from '@stitches/react'
+import type { CSS as StitchesCSS } from '@stitches/react'
+import type StyledComponent from '@stitches/react/types/styled-component'
+import type Util from '@stitches/react/types/util'
+import type CSSUtil from '@stitches/react/types/css-util'
+import {
+  stitches as config,
+  css as cssImport,
+  styled as stitchesStyled,
+} from '../stitches.config'
 
 // Support a css prop when used with twins styled.div({}) syntax
-type CSSProp<T = AnyIfEmpty<DefaultTheme>> = string | CSSObject
+type CSSProp = StitchesCSS<typeof config>
+
+type Media = typeof config.media
+type Theme = typeof config.theme
+type ThemeMap = typeof config.themeMap
+type Utils = typeof config.utils
+
+type Styled<Type> = {
+  <
+    Composers extends (
+      | string
+      | React.ComponentType<unknown>
+      | Util.Function
+      | { [name: string]: unknown }
+    )[],
+    CSS = CSSUtil.CSS<Media, Theme, ThemeMap, Utils>,
+  >(
+    ...composers: {
+      [K in keyof Composers]: string extends Composers[K] // Strings, React Components, and Functions can be skipped over
+        ? Composers[K]
+        : Composers[K] extends
+            | string
+            | React.ComponentType<unknown>
+            | Util.Function
+        ? Composers[K]
+        : RemoveIndex<CSS> & {
+            /** The **variants** property lets you set a subclass of styles based on a key-value pair.
+             *
+             * [Read Documentation](https://stitches.dev/docs/variants)
+             */
+            variants?: {
+              [_Name in string]: {
+                [_Pair in number | string]: CSS
+              }
+            }
+            /** The **compoundVariants** property lets you to set a subclass of styles based on a combination of active variants.
+             *
+             * [Read Documentation](https://stitches.dev/docs/variants#compound-variants)
+             */
+            compoundVariants?: (('variants' extends keyof Composers[K]
+              ? {
+                  [Name in keyof Composers[K]['variants']]?:
+                    | Util.Widen<keyof Composers[K]['variants'][Name]>
+                    | Util.String
+                }
+              : Util.WideObject) & {
+              css: CSS
+            })[]
+            /** The **defaultVariants** property allows you to predefine the active key-value pairs of variants.
+             *
+             * [Read Documentation](https://stitches.dev/docs/variants#default-variants)
+             */
+            defaultVariants?: 'variants' extends keyof Composers[K]
+              ? {
+                  [Name in keyof Composers[K]['variants']]?:
+                    | Util.Widen<keyof Composers[K]['variants'][Name]>
+                    | Util.String
+                }
+              : Util.WideObject
+          } & CSS & {
+              [K2 in keyof Composers[K]]: K2 extends
+                | 'compoundVariants'
+                | 'defaultVariants'
+                | 'variants'
+                ? unknown
+                : K2 extends keyof CSS
+                ? CSS[K2]
+                : unknown
+            }
+    }
+  ): StyledComponent.StyledComponent<
+    Type,
+    StyledComponent.StyledComponentProps<Composers>,
+    Media,
+    CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+  >
+}
 
 declare module 'react' {
   // The css prop
@@ -235,14 +318,12 @@ declare module 'react' {
 
 // Support twins styled.div({}) syntax
 type StyledTags = {
-  [Tag in keyof JSX.IntrinsicElements]: CreateStyledComponent<
-    JSX.IntrinsicElements[Tag]
-  >
+  [Tag in keyof JSX.IntrinsicElements]: Styled<Tag>
 }
 
 declare module 'twin.macro' {
   // The styled and css imports
-  const styled: typeof StyledTags | typeof styledImport
+  const styled: StyledTags & typeof stitchesStyled
   const css: typeof cssImport
 }
 ```

--- a/next-stitches-typescript/types/twin.d.ts
+++ b/next-stitches-typescript/types/twin.d.ts
@@ -1,9 +1,92 @@
 import 'twin.macro'
 import { css as cssImport } from '@stitches/react'
-import styledImport from '@stitches/react'
+import type StyledComponent from '@stitches/react/types/styled-component'
+import type Util from '@stitches/react/types/util'
+import type CSSUtil from '@stitches/react/types/css-util'
+import {
+  stitches as config,
+  css as cssImport,
+  styled as stitchesStyled,
+} from '../stitches.config'
 
 // Support a css prop when used with twins styled.div({}) syntax
 type CSSProp<T = AnyIfEmpty<DefaultTheme>> = string | CSSObject
+
+type Media = typeof config.media
+type Theme = typeof config.theme
+type ThemeMap = typeof config.themeMap
+type Utils = typeof config.utils
+
+type Styled<Type> = {
+  <
+    Composers extends (
+      | string
+      | React.ComponentType<unknown>
+      | Util.Function
+      | { [name: string]: unknown }
+    )[],
+    CSS = CSSUtil.CSS<Media, Theme, ThemeMap, Utils>,
+  >(
+    ...composers: {
+      [K in keyof Composers]: string extends Composers[K] // Strings, React Components, and Functions can be skipped over
+        ? Composers[K]
+        : Composers[K] extends
+            | string
+            | React.ComponentType<unknown>
+            | Util.Function
+        ? Composers[K]
+        : RemoveIndex<CSS> & {
+            /** The **variants** property lets you set a subclass of styles based on a key-value pair.
+             *
+             * [Read Documentation](https://stitches.dev/docs/variants)
+             */
+            variants?: {
+              [_Name in string]: {
+                [_Pair in number | string]: CSS
+              }
+            }
+            /** The **compoundVariants** property lets you to set a subclass of styles based on a combination of active variants.
+             *
+             * [Read Documentation](https://stitches.dev/docs/variants#compound-variants)
+             */
+            compoundVariants?: (('variants' extends keyof Composers[K]
+              ? {
+                  [Name in keyof Composers[K]['variants']]?:
+                    | Util.Widen<keyof Composers[K]['variants'][Name]>
+                    | Util.String
+                }
+              : Util.WideObject) & {
+              css: CSS
+            })[]
+            /** The **defaultVariants** property allows you to predefine the active key-value pairs of variants.
+             *
+             * [Read Documentation](https://stitches.dev/docs/variants#default-variants)
+             */
+            defaultVariants?: 'variants' extends keyof Composers[K]
+              ? {
+                  [Name in keyof Composers[K]['variants']]?:
+                    | Util.Widen<keyof Composers[K]['variants'][Name]>
+                    | Util.String
+                }
+              : Util.WideObject
+          } & CSS & {
+              [K2 in keyof Composers[K]]: K2 extends
+                | 'compoundVariants'
+                | 'defaultVariants'
+                | 'variants'
+                ? unknown
+                : K2 extends keyof CSS
+                ? CSS[K2]
+                : unknown
+            }
+    }
+  ): StyledComponent.StyledComponent<
+    Type,
+    StyledComponent.StyledComponentProps<Composers>,
+    Media,
+    CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+  >
+}
 
 declare module 'react' {
   // The css prop
@@ -20,14 +103,11 @@ declare module 'react' {
 
 // Support twins styled.div({}) syntax
 type StyledTags = {
-  [Tag in keyof JSX.IntrinsicElements]: CreateStyledComponent<
-    JSX.IntrinsicElements[Tag]
-  >
+  [Tag in keyof JSX.IntrinsicElements]: Styled<Tag>
 }
 
 declare module 'twin.macro' {
   // The styled and css imports
-  const styled: StyledTags & typeof styledImport
+  const styled: StyledTags & typeof stitchesStyled
   const css: typeof cssImport
 }
-

--- a/next-stitches-typescript/types/twin.d.ts
+++ b/next-stitches-typescript/types/twin.d.ts
@@ -1,5 +1,6 @@
 import 'twin.macro'
 import { css as cssImport } from '@stitches/react'
+import type { CSS as StitchesCSS } from '@stitches/react'
 import type StyledComponent from '@stitches/react/types/styled-component'
 import type Util from '@stitches/react/types/util'
 import type CSSUtil from '@stitches/react/types/css-util'
@@ -10,7 +11,7 @@ import {
 } from '../stitches.config'
 
 // Support a css prop when used with twins styled.div({}) syntax
-type CSSProp<T = AnyIfEmpty<DefaultTheme>> = string | CSSObject
+type CSSProp = StitchesCSS<typeof config>
 
 type Media = typeof config.media
 type Theme = typeof config.theme


### PR DESCRIPTION
While we were able to get auto-completion for which attributes were available on `styled` from #96, these attributes were type `any` as the type definitions for them didn't work properly. This resolves that by borrowing the `styled` [type definition from stitches](https://github.com/stitchesjs/stitches/blob/canary/packages/react/types/stitches.d.ts#L205-L276=) and adjusting it to match twin's modified syntax, while obeying the user's chosen config.

Now we get full intellisense complete with automatic variant type inference :))

![image](https://user-images.githubusercontent.com/25019123/177952222-3b4acb12-c97e-4e06-acc0-a2c81a18d692.png)
![image](https://user-images.githubusercontent.com/25019123/177952148-ed37b8f5-fc66-466b-a849-ceee7ff4093b.png)

This does feel like a bit of a heavy and inelegant solution, but I'm not sure if there's any alternative solution we can use. If you have any ideas please do let me know.

We also fix an issue where stitches' standard `styled` function type was added as a property of twin's `styled` type here instead of being at the root, preventing the use of `styled(component, { ...styles })`, and fix `CSSProps` being type `any`.

Thanks to @nibtime for those last 2 fixes (https://github.com/ben-rogerson/twin.macro/issues/537#issuecomment-1049336741)
