### PR TITLE
Fix(next-emotion, next-emotion-typescript): remove unnecessary code and libraries

### DIFF
--- a/next-emotion-typescript/package-lock.json
+++ b/next-emotion-typescript/package-lock.json
@@ -7,9 +7,7 @@
     "": {
       "version": "0.0.0",
       "dependencies": {
-        "@emotion/css": "^11.10.5",
         "@emotion/react": "^11.10.5",
-        "@emotion/server": "^11.10.0",
         "@emotion/styled": "^11.10.5",
         "next": "^13.1.1",
         "react": "^18.2.0",
@@ -668,26 +666,6 @@
         "stylis": "4.1.3"
       }
     },
-    "node_modules/@emotion/css": {
-      "version": "11.10.5",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.5.tgz",
-      "integrity": "sha512-maJy0wG82hWsiwfJpc3WrYsyVwUbdu+sdIseKUB+/OLjB8zgc3tqkT6eO0Yt0AhIkJwGGnmMY/xmQwEAgQ4JHA==",
-      "dependencies": {
-        "@emotion/babel-plugin": "^11.10.5",
-        "@emotion/cache": "^11.10.5",
-        "@emotion/serialize": "^1.1.1",
-        "@emotion/sheet": "^1.2.1",
-        "@emotion/utils": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@emotion/hash": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
@@ -743,25 +721,6 @@
         "@emotion/unitless": "^0.8.0",
         "@emotion/utils": "^1.2.0",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/server": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.10.0.tgz",
-      "integrity": "sha512-MTvJ21JPo9aS02GdjFW4nhdwOi2tNNpMmAM/YED0pkxzjDNi5WbiTwXqaCnvLc2Lr8NFtjhT0az1vTJyLIHYcw==",
-      "dependencies": {
-        "@emotion/utils": "^1.2.0",
-        "html-tokenize": "^2.0.0",
-        "multipipe": "^1.0.2",
-        "through": "^2.3.8"
-      },
-      "peerDependencies": {
-        "@emotion/css": "^11.0.0-rc.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/css": {
-          "optional": true
-        }
       }
     },
     "node_modules/@emotion/sheet": {
@@ -1554,10 +1513,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "0.1.2",
-      "license": "MIT"
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "license": "MIT",
@@ -1690,10 +1645,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
       "license": "MIT",
@@ -1768,37 +1719,6 @@
       "version": "1.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/duplexer2/node_modules/isarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
@@ -2071,20 +1991,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "node_modules/html-tokenize": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "~0.1.1",
-        "inherits": "~2.0.1",
-        "minimist": "~1.2.5",
-        "readable-stream": "~1.0.27-1",
-        "through2": "~0.4.1"
-      },
-      "bin": {
-        "html-tokenize": "bin/cmd.js"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "license": "MIT",
@@ -2098,10 +2004,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2154,10 +2056,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -2360,19 +2258,12 @@
     },
     "node_modules/minimist": {
       "version": "1.2.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
-    },
-    "node_modules/multipipe": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "duplexer2": "^0.1.2",
-        "object-assign": "^4.1.0"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -2454,13 +2345,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "dev": true,
@@ -2468,10 +2352,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/object-keys": {
-      "version": "0.4.0",
-      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -2720,10 +2600,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "dev": true,
@@ -2803,16 +2679,6 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "1.0.34",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
       }
     },
     "node_modules/readdirp": {
@@ -3013,10 +2879,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
@@ -3227,27 +3089,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "license": "MIT"
-    },
-    "node_modules/through2": {
-      "version": "0.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~1.0.17",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/through2/node_modules/xtend": {
-      "version": "2.1.2",
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "license": "MIT",
@@ -3409,6 +3250,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/watchpack": {
@@ -3940,18 +3782,6 @@
         "stylis": "4.1.3"
       }
     },
-    "@emotion/css": {
-      "version": "11.10.5",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.5.tgz",
-      "integrity": "sha512-maJy0wG82hWsiwfJpc3WrYsyVwUbdu+sdIseKUB+/OLjB8zgc3tqkT6eO0Yt0AhIkJwGGnmMY/xmQwEAgQ4JHA==",
-      "requires": {
-        "@emotion/babel-plugin": "^11.10.5",
-        "@emotion/cache": "^11.10.5",
-        "@emotion/serialize": "^1.1.1",
-        "@emotion/sheet": "^1.2.1",
-        "@emotion/utils": "^1.2.0"
-      }
-    },
     "@emotion/hash": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
@@ -3995,17 +3825,6 @@
         "@emotion/unitless": "^0.8.0",
         "@emotion/utils": "^1.2.0",
         "csstype": "^3.0.2"
-      }
-    },
-    "@emotion/server": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.10.0.tgz",
-      "integrity": "sha512-MTvJ21JPo9aS02GdjFW4nhdwOi2tNNpMmAM/YED0pkxzjDNi5WbiTwXqaCnvLc2Lr8NFtjhT0az1vTJyLIHYcw==",
-      "requires": {
-        "@emotion/utils": "^1.2.0",
-        "html-tokenize": "^2.0.0",
-        "multipipe": "^1.0.2",
-        "through": "^2.3.8"
       }
     },
     "@emotion/sheet": {
@@ -4539,9 +4358,6 @@
         "update-browserslist-db": "^1.0.9"
       }
     },
-    "buffer-from": {
-      "version": "0.1.2"
-    },
     "callsites": {
       "version": "3.1.0"
     },
@@ -4630,9 +4446,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "core-util-is": {
-      "version": "1.0.3"
-    },
     "cosmiconfig": {
       "version": "7.0.1",
       "requires": {
@@ -4676,35 +4489,6 @@
     "dlv": {
       "version": "1.1.3",
       "dev": true
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "requires": {
-        "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "electron-to-chromium": {
       "version": "1.4.284",
@@ -4892,25 +4676,12 @@
         "react-is": "^16.7.0"
       }
     },
-    "html-tokenize": {
-      "version": "2.0.1",
-      "requires": {
-        "buffer-from": "~0.1.1",
-        "inherits": "~2.0.1",
-        "minimist": "~1.2.5",
-        "readable-stream": "~1.0.27-1",
-        "through2": "~0.4.1"
-      }
-    },
     "import-fresh": {
       "version": "3.3.0",
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       }
-    },
-    "inherits": {
-      "version": "2.0.4"
     },
     "is-arrayish": {
       "version": "0.2.1"
@@ -4942,9 +4713,6 @@
     "is-number": {
       "version": "7.0.0",
       "dev": true
-    },
-    "isarray": {
-      "version": "0.0.1"
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -5075,17 +4843,11 @@
       }
     },
     "minimist": {
-      "version": "1.2.6"
+      "version": "1.2.6",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2"
-    },
-    "multipipe": {
-      "version": "1.0.2",
-      "requires": {
-        "duplexer2": "^0.1.2",
-        "object-assign": "^4.1.0"
-      }
     },
     "nanoid": {
       "version": "3.3.4"
@@ -5129,15 +4891,9 @@
       "version": "3.0.0",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1"
-    },
     "object-hash": {
       "version": "3.0.0",
       "dev": true
-    },
-    "object-keys": {
-      "version": "0.4.0"
     },
     "p-limit": {
       "version": "2.3.0",
@@ -5259,9 +5015,6 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1"
-    },
     "punycode": {
       "version": "2.1.1",
       "dev": true
@@ -5305,15 +5058,6 @@
       "dev": true,
       "requires": {
         "pify": "^2.3.0"
-      }
-    },
-    "readable-stream": {
-      "version": "1.0.34",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
       }
     },
     "readdirp": {
@@ -5448,9 +5192,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "0.10.31"
-    },
     "styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -5570,24 +5311,6 @@
         }
       }
     },
-    "through": {
-      "version": "2.3.8"
-    },
-    "through2": {
-      "version": "0.4.2",
-      "requires": {
-        "readable-stream": "~1.0.17",
-        "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "2.1.2",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
-    },
     "to-fast-properties": {
       "version": "2.0.0"
     },
@@ -5691,7 +5414,8 @@
       }
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "watchpack": {
       "version": "2.4.0",

--- a/next-emotion-typescript/package.json
+++ b/next-emotion-typescript/package.json
@@ -10,9 +10,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@emotion/css": "^11.10.5",
     "@emotion/react": "^11.10.5",
-    "@emotion/server": "^11.10.0",
     "@emotion/styled": "^11.10.5",
     "next": "^13.1.1",
     "react": "^18.2.0",

--- a/next-emotion-typescript/pages/_app.tsx
+++ b/next-emotion-typescript/pages/_app.tsx
@@ -1,13 +1,11 @@
-import { cache } from '@emotion/css'
-import { CacheProvider } from '@emotion/react'
 import type { AppProps } from 'next/app'
-import GlobalStyles from './../styles/GlobalStyles'
+import GlobalStyles from '../styles/GlobalStyles'
 
 const App = ({ Component, pageProps }: AppProps) => (
-  <CacheProvider value={cache}>
+  <>
     <GlobalStyles />
     <Component {...pageProps} />
-  </CacheProvider>
+  </>
 )
 
 export default App

--- a/next-emotion-typescript/pages/_document.tsx
+++ b/next-emotion-typescript/pages/_document.tsx
@@ -1,52 +1,16 @@
-import Document, {
-  Html,
-  Head,
-  Main,
-  NextScript,
-  DocumentContext,
-  DocumentInitialProps
-} from 'next/document'
-import { extractCritical } from '@emotion/server'
+import React from 'react'
+import { Head, Html, Main, NextScript } from 'next/document'
 
-type NewDocumentInitialProps = DocumentInitialProps & {
-  ids: string[]
-  css: string
+const Document = () => {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
 }
 
-class CustomDocument extends Document<NewDocumentInitialProps> {
-  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
-    const initialProps = await Document.getInitialProps(ctx)
-    const critical = extractCritical(initialProps.html)
-    initialProps.html = critical.html
-    initialProps.styles = (
-      <>
-        {initialProps.styles}
-        <style
-          data-emotion-css={critical.ids.join(' ')}
-          dangerouslySetInnerHTML={{ __html: critical.css }}
-        />
-      </>
-    )
-
-    return initialProps
-  }
-
-  render() {
-    return (
-      <Html lang="en">
-        <Head>
-          <style
-            data-emotion-css={this.props?.ids?.join(' ')}
-            dangerouslySetInnerHTML={{ __html: this.props.css }}
-          />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    )
-  }
-}
-
-export default CustomDocument
+export default Document

--- a/next-emotion/README.md
+++ b/next-emotion/README.md
@@ -39,7 +39,7 @@ npx create-next-app
 Install the dependencies
 
 ```shell
-npm install @emotion/react @emotion/styled @emotion/css @emotion/server
+npm install @emotion/react @emotion/styled
 npm install -D twin.macro tailwindcss @emotion/babel-plugin babel-plugin-macros @babel/preset-react babel-loader babel-plugin-macros
 ```
 
@@ -53,7 +53,7 @@ yarn create next-app
 Install the dependencies
 
 ```shell
-yarn add @emotion/react @emotion/styled @emotion/css @emotion/server
+yarn add @emotion/react @emotion/styled
 yarn add -D twin.macro tailwindcss @emotion/babel-plugin babel-plugin-macros
 ```
 
@@ -98,61 +98,13 @@ import { CacheProvider } from '@emotion/react'
 import GlobalStyles from './../styles/GlobalStyles'
 
 const App = ({ Component, pageProps }) => (
-  <CacheProvider value={cache}>
+  <>
     <GlobalStyles />
     <Component {...pageProps} />
-  </CacheProvider>
+  </>
 )
 
 export default App
-```
-
-### SSR styles setup
-
-Creating a `_document.js` file like this will put critical styles in the head of the page.
-Without this step, you’ll notice a difference between the SSR generated styles and the ones that hydrate on the client side.
-
-```js
-// pages/_document.js
-import React from 'react'
-import Document, { Html, Head, Main, NextScript } from 'next/document'
-import { extractCritical } from '@emotion/server'
-
-export default class MyDocument extends Document {
-  static async getInitialProps(ctx) {
-    const initialProps = await Document.getInitialProps(ctx)
-    const critical = extractCritical(initialProps.html)
-    initialProps.html = critical.html
-    initialProps.styles = (
-      <React.Fragment>
-        {initialProps.styles}
-        <style
-          data-emotion-css={critical.ids.join(' ')}
-          dangerouslySetInnerHTML={{ __html: critical.css }}
-        />
-      </React.Fragment>
-    )
-
-    return initialProps
-  }
-
-  render() {
-    return (
-      <Html lang="en">
-        <Head>
-          <style
-            data-emotion-css={this.props.ids.join(' ')}
-            dangerouslySetInnerHTML={{ __html: this.props.css }}
-          />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    )
-  }
-}
 ```
 
 ### Add the twin config (optional)

--- a/next-emotion/package-lock.json
+++ b/next-emotion/package-lock.json
@@ -5,9 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@emotion/css": "^11.10.5",
         "@emotion/react": "^11.10.5",
-        "@emotion/server": "^11.10.0",
         "@emotion/styled": "^11.10.5",
         "next": "^13.1.1",
         "react": "^18.2.0",
@@ -478,26 +476,6 @@
         "stylis": "4.1.3"
       }
     },
-    "node_modules/@emotion/css": {
-      "version": "11.10.5",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.5.tgz",
-      "integrity": "sha512-maJy0wG82hWsiwfJpc3WrYsyVwUbdu+sdIseKUB+/OLjB8zgc3tqkT6eO0Yt0AhIkJwGGnmMY/xmQwEAgQ4JHA==",
-      "dependencies": {
-        "@emotion/babel-plugin": "^11.10.5",
-        "@emotion/cache": "^11.10.5",
-        "@emotion/serialize": "^1.1.1",
-        "@emotion/sheet": "^1.2.1",
-        "@emotion/utils": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@emotion/hash": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
@@ -553,25 +531,6 @@
         "@emotion/unitless": "^0.8.0",
         "@emotion/utils": "^1.2.0",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/server": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.10.0.tgz",
-      "integrity": "sha512-MTvJ21JPo9aS02GdjFW4nhdwOi2tNNpMmAM/YED0pkxzjDNi5WbiTwXqaCnvLc2Lr8NFtjhT0az1vTJyLIHYcw==",
-      "dependencies": {
-        "@emotion/utils": "^1.2.0",
-        "html-tokenize": "^2.0.0",
-        "multipipe": "^1.0.2",
-        "through": "^2.3.8"
-      },
-      "peerDependencies": {
-        "@emotion/css": "^11.0.0-rc.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/css": {
-          "optional": true
-        }
       }
     },
     "node_modules/@emotion/sheet": {
@@ -1370,11 +1329,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1513,11 +1467,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -1603,41 +1552,6 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/duplexer2/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
@@ -1935,21 +1849,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "node_modules/html-tokenize": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
-      "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
-      "dependencies": {
-        "buffer-from": "~0.1.1",
-        "inherits": "~2.0.1",
-        "minimist": "~1.2.5",
-        "readable-stream": "~1.0.27-1",
-        "through2": "~0.4.1"
-      },
-      "bin": {
-        "html-tokenize": "bin/cmd.js"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -1964,11 +1863,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2027,11 +1921,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -2243,6 +2132,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2251,15 +2141,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/multipipe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
-      "integrity": "sha512-6uiC9OvY71vzSGX8lZvSqscE7ft9nPupJ8fMjrCNRAUy2LREUW42UL+V/NTrogr6rFgRydUrCX4ZitfpSNkSCQ==",
-      "dependencies": {
-        "duplexer2": "^0.1.2",
-        "object-assign": "^4.1.0"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -2340,14 +2221,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2611,11 +2484,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2704,17 +2572,6 @@
         "pify": "^2.3.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2801,7 +2658,9 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -2931,11 +2790,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
@@ -3177,36 +3031,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
-    },
-    "node_modules/through2": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
-      "dependencies": {
-        "readable-stream": "~1.0.17",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/through2/node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="
-    },
-    "node_modules/through2/node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -3359,7 +3183,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
@@ -3849,18 +3674,6 @@
         "stylis": "4.1.3"
       }
     },
-    "@emotion/css": {
-      "version": "11.10.5",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.5.tgz",
-      "integrity": "sha512-maJy0wG82hWsiwfJpc3WrYsyVwUbdu+sdIseKUB+/OLjB8zgc3tqkT6eO0Yt0AhIkJwGGnmMY/xmQwEAgQ4JHA==",
-      "requires": {
-        "@emotion/babel-plugin": "^11.10.5",
-        "@emotion/cache": "^11.10.5",
-        "@emotion/serialize": "^1.1.1",
-        "@emotion/sheet": "^1.2.1",
-        "@emotion/utils": "^1.2.0"
-      }
-    },
     "@emotion/hash": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
@@ -3904,17 +3717,6 @@
         "@emotion/unitless": "^0.8.0",
         "@emotion/utils": "^1.2.0",
         "csstype": "^3.0.2"
-      }
-    },
-    "@emotion/server": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.10.0.tgz",
-      "integrity": "sha512-MTvJ21JPo9aS02GdjFW4nhdwOi2tNNpMmAM/YED0pkxzjDNi5WbiTwXqaCnvLc2Lr8NFtjhT0az1vTJyLIHYcw==",
-      "requires": {
-        "@emotion/utils": "^1.2.0",
-        "html-tokenize": "^2.0.0",
-        "multipipe": "^1.0.2",
-        "through": "^2.3.8"
       }
     },
     "@emotion/sheet": {
@@ -4502,11 +4304,6 @@
         "update-browserslist-db": "^1.0.9"
       }
     },
-    "buffer-from": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4610,11 +4407,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
     "cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4674,43 +4466,6 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "requires": {
-        "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "electron-to-chromium": {
       "version": "1.4.284",
@@ -4945,18 +4700,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "html-tokenize": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
-      "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
-      "requires": {
-        "buffer-from": "~0.1.1",
-        "inherits": "~2.0.1",
-        "minimist": "~1.2.5",
-        "readable-stream": "~1.0.27-1",
-        "through2": "~0.4.1"
-      }
-    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4965,11 +4708,6 @@
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -5013,11 +4751,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -5176,21 +4909,13 @@
     "minimist": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "multipipe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
-      "integrity": "sha512-6uiC9OvY71vzSGX8lZvSqscE7ft9nPupJ8fMjrCNRAUy2LREUW42UL+V/NTrogr6rFgRydUrCX4ZitfpSNkSCQ==",
-      "requires": {
-        "duplexer2": "^0.1.2",
-        "object-assign": "^4.1.0"
-      }
     },
     "nanoid": {
       "version": "3.3.4",
@@ -5239,11 +4964,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-hash": {
       "version": "3.0.0",
@@ -5401,11 +5121,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -5465,17 +5180,6 @@
         "pify": "^2.3.0"
       }
     },
-    "readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5529,7 +5233,9 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "peer": true
     },
     "scheduler": {
       "version": "0.23.0",
@@ -5637,11 +5343,6 @@
           "peer": true
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "styled-jsx": {
       "version": "5.1.1",
@@ -5796,35 +5497,6 @@
         }
       }
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
-    },
-    "through2": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
-      "requires": {
-        "readable-stream": "~1.0.17",
-        "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
-    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5930,7 +5602,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "watchpack": {
       "version": "2.4.0",

--- a/next-emotion/package.json
+++ b/next-emotion/package.json
@@ -10,9 +10,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@emotion/css": "^11.10.5",
     "@emotion/react": "^11.10.5",
-    "@emotion/server": "^11.10.0",
     "@emotion/styled": "^11.10.5",
     "next": "^13.1.1",
     "react": "^18.2.0",

--- a/next-emotion/pages/_app.js
+++ b/next-emotion/pages/_app.js
@@ -1,12 +1,10 @@
-import { cache } from '@emotion/css'
-import { CacheProvider } from '@emotion/react'
-import GlobalStyles from './../styles/GlobalStyles'
+import GlobalStyles from '../styles/GlobalStyles'
 
 const App = ({ Component, pageProps }) => (
-  <CacheProvider value={cache}>
+  <>
     <GlobalStyles />
     <Component {...pageProps} />
-  </CacheProvider>
+  </>
 )
 
 export default App

--- a/next-emotion/pages/_document.js
+++ b/next-emotion/pages/_document.js
@@ -1,34 +1,16 @@
 import React from 'react'
-import Document, { Html, Head, Main, NextScript } from 'next/document'
-import { extractCritical } from '@emotion/server'
+import { Head, Html, Main, NextScript } from 'next/document'
 
-export default class MyDocument extends Document {
-  static async getInitialProps(ctx) {
-    const initialProps = await Document.getInitialProps(ctx)
-    const critical = extractCritical(initialProps.html)
-    initialProps.html = critical.html
-    initialProps.styles = (
-      <React.Fragment>
-        {initialProps.styles}
-        <style
-          data-emotion-css={critical.ids.join(' ')}
-          dangerouslySetInnerHTML={{ __html: critical.css }}
-        />
-      </React.Fragment>
-    )
-
-    return initialProps
-  }
-
-  render() {
-    return (
-      <Html lang="en">
-        <Head />
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    )
-  }
+const Document = () => {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
 }
+
+export default Document


### PR DESCRIPTION
Hi, I'm trying to apply twin.macro and emotion to Next js. I referred to the example in this repository while trying to apply it, but there were some unnecessary codes, so I modified it.

<br/>

#### 1. You don't need any ssr settings in `_document.tsx` file. 
According to the emotion official documentation, version 10 or higher does not require any special settings for ssr in Next js.
- https://emotion.sh/docs/ssr#nextjs

#### 2. For the reason of the previous item, the `@emotion/css` and `@emotion/server` are no longer needed.
In react-emotion example, I confirmed that twin.macro can be used only with @emotion/react and @emotion/styled.
- https://github.com/ben-rogerson/twin.examples/blob/master/react-emotion/package.json

<br/>

For this reason, I modified the code of next-emotion and next-emotion-typescript examples.


---

### Changes
- Removed ssr setting in `_document.tsx`
- Removed CacheProvider in `_app.tsx`
- Removed `@emotion/css`, `@emotion/server`
- Update README

### demo
- https://codesandbox.io/p/sandbox/twin-macro-with-nextjs-emotion-3w57s3
