### PR TITLE
Update next-styled-comp-ts twin.d.ts

### DIFF
--- a/next-styled-components-typescript/types/twin.d.ts
+++ b/next-styled-components-typescript/types/twin.d.ts
@@ -19,12 +19,3 @@ declare module 'react' {
     tw?: string
   }
 }
-
-// The 'as' prop on styled components
-declare global {
-  namespace JSX {
-    interface IntrinsicAttributes<T> extends DOMAttributes<T> {
-      as?: string | Element
-    }
-  }
-}


### PR DESCRIPTION
solved: typescript will throw err ts(2322) when using key prop with func components; and I think the declaration was old and styled-components doesn't need it after v6 (https://styled-components.com/docs/api#typescript)